### PR TITLE
Small UX improvements for language switcher

### DIFF
--- a/src/components/language.js
+++ b/src/components/language.js
@@ -22,9 +22,10 @@ const LanguageList = styled.ol`
 const LanguageItem = styled.li`
     & + ::before {
         content: "|";
+        padding: 0 3px;
     }
     & > a {
-        color: ${props => (props.active ? theme.color : theme.color50)};
+        color: ${props => (props.active ? theme.color50 : theme.color)};
     }
 `
 

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -130,7 +130,6 @@ const Navigation = ({ navItems }) => {
                 </Brand>
 
                 <Container>
-                    <Language />
                     <TransitionGroup component={null}>
                         <CSSTransition classNames="fade" timeout={0}>
                             <HamburgerContainer onClick={toggleMenu}>
@@ -150,6 +149,7 @@ const Navigation = ({ navItems }) => {
                                 </li>
                             ))}
                     </NavList>
+                    <Language />
                 </Container>
             </Nav>
             <Menu navItems={navItems} menuOpen={open} toggleMenu={toggleMenu} />


### PR DESCRIPTION
I think that the link color for the language switcher should be reversed as links to click appear white not grey.
Also I think that the common format is to have the language switcher at the end of the navigation.
Lastly I think the padding between en | de could be a little bit more. 
<img width="1384" alt="Screenshot 2020-09-08 at 16 32 25" src="https://user-images.githubusercontent.com/9334296/92490165-f8647680-f1f0-11ea-93a7-d5f1f0f01572.png">
Refer to screenshot
